### PR TITLE
fix false positive snapshot tests that depend on timezone

### DIFF
--- a/internal/testing/jest-config.ts
+++ b/internal/testing/jest-config.ts
@@ -27,6 +27,7 @@ const jestConfig: Config.InitialOptions = {
     ],
   },
   transform: { "^.+\\.[jt]sx?$": ["@swc/jest", swc] },
+  globalSetup: "<rootDir>/internal/testing/jest-global.ts",
   setupFiles: ["<rootDir>/internal/testing/jest-setup.ts"],
   testPathIgnorePatterns: ["node_modules", "\\.cache", "<rootDir>.*/public"],
   transformIgnorePatterns: ["node_modules/(?!(gatsby|gatsby-script)/)"],

--- a/internal/testing/jest-global.ts
+++ b/internal/testing/jest-global.ts
@@ -1,0 +1,4 @@
+module.exports = async () => {
+  // snapshot tests depend on a timezone
+  process.env.TZ = "Europe/London";
+}


### PR DESCRIPTION
## Description

the following fails 7 snapshot tests: export TZ="Pacific/Honolulu" && npm test 
the following fixes those 7 snapshot tests: export TZ="Europe/London" && npm test

The patch fixes the timezone prior to test setup. This requires jest global configuration rather than the setupFiles configuration because the latter executes too late in the setup process. 

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
