### PR TITLE
Remove unused packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,6 @@
     "rimraf": "5.0.1",
     "sass": "^1.65.1",
     "semantic-release": "^21.0.9",
-    "source-map-support": "^0.5.21",
     "stylelint": "^15.10.3",
     "stylelint-config-recommended-scss": "^13.0.0",
     "stylelint-order": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "gatsby-source-filesystem": "^4.25.0",
     "gatsby-transformer-remark": "^5.25.1",
     "gatsby-transformer-sharp": "^4.25.0",
-    "prismjs": "^1.29.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },


### PR DESCRIPTION
## Description

Hello,

I noticed that the `source-map-support` and `prismjs` packages declared in the package.json file are unused in the source files of the project. Removing unused dependencies has an impact on the number of CI build minutes that are consumed during CI due to bumpings of unused dependencies by bots. In fact, I noticed the commits, bumping versions of these unused dependencies made by the renovate bot, and those commits consume a substantial amount of CI build time.
On the other hand, removing unused dependencies may reduce the number of pull requests needed to be reviewed by developers for such cases. Thus, I am creating this PR to remove those unused dependencies.


## Related Issues

NA
